### PR TITLE
Add MoE token choice layer

### DIFF
--- a/src/benchmarks/profiles.py
+++ b/src/benchmarks/profiles.py
@@ -1,5 +1,5 @@
 from pytfex.utils import set_seed
-from pytfex.models import get_model, GPTMoEConfig, GPTBasicConfig
+from pytfex.models import get_model, GPTExpertChoiceMoEConfig, GPTTokenChoiceMoEConfig, GPTBasicConfig
 import torch
 from pytfex.utils import count_parameters
 from profiling import Profiling
@@ -7,7 +7,8 @@ from profiling import Profiling
 
 benchmarks = [
     GPTBasicConfig(num_layers=1, hdn_dim=1024),
-    GPTMoEConfig(num_layers=1, num_experts=21, c=1, hdn_dim=512, ),
+    GPTExpertChoiceMoEConfig(num_layers=1, num_experts=21, c=1, hdn_dim=512, ),
+    GPTTokenChoiceMoEConfig(num_layers=1, num_experts=21, k=1, hdn_dim=512, ),
 ]
 
 for config in benchmarks:

--- a/src/pytfex/models/__init__.py
+++ b/src/pytfex/models/__init__.py
@@ -1,16 +1,32 @@
-from pytfex.models.moe import get_moe_gpt_config
+from pytfex.models.ec_moe import get_ec_moe_gpt_config
+from pytfex.models.tc_moe import get_tc_moe_gpt_config
 from pytfex.models.basic import get_basic_gpt_config
 from pytfex.transformer.make_model import init_from_yml_string
 from dataclasses import dataclass
 
 
 @dataclass
-class GPTMoEConfig:
-    model_type: str = 'gpt-moe'
+class GPTExpertChoiceMoEConfig:
+    model_type: str = 'gpt-ec-moe'
     vcb_size: int = 65
     hdn_dim: int = 256
     blk_size: int = 256
     c: int = 2
+    num_experts: int = 4
+    batch_size: int = 32
+    num_layers: int = 2
+    mlp_hdn_dim: int = 1024
+    dropout: float = 0.1
+    num_heads: int = 4
+
+
+@dataclass
+class GPTTokenChoiceMoEConfig:
+    model_type: str = 'gpt-tc-moe'
+    vcb_size: int = 65
+    hdn_dim: int = 256
+    blk_size: int = 256
+    k: int = 2
     num_experts: int = 4
     batch_size: int = 32
     num_layers: int = 2
@@ -33,7 +49,8 @@ class GPTBasicConfig:
 
 def get_model(config):
     config_str = {
-        'gpt-moe': get_moe_gpt_config,
+        'gpt-ec-moe': get_ec_moe_gpt_config,
+        'gpt-tc-moe': get_tc_moe_gpt_config,
         'gpt-basic': get_basic_gpt_config,
     }[config.model_type](config)
     return init_from_yml_string(config_str)

--- a/src/pytfex/models/ec_moe.py
+++ b/src/pytfex/models/ec_moe.py
@@ -1,4 +1,4 @@
-def get_moe_gpt_config(config):
+def get_ec_moe_gpt_config(config):
     return f"""
         type: 'GPT'
         params:
@@ -30,7 +30,7 @@ def get_moe_gpt_config(config):
                                 num_heads: {config.num_heads}
                                 dropout: {config.dropout}
                         mlp:
-                            type: 'MoE'
+                            type: 'ExpertChoiceMoE'
                             params:
                                 hidden_dim: {config.hdn_dim}
                                 c: {config.c}

--- a/src/pytfex/models/tc_moe.py
+++ b/src/pytfex/models/tc_moe.py
@@ -1,0 +1,49 @@
+def get_tc_moe_gpt_config(config):
+    return f"""
+        type: 'GPT'
+        params:
+            dropout: {config.dropout}
+            hidden_dim: {config.hdn_dim}
+            num_heads: {config.num_heads}
+            dropout: {config.dropout}
+            embedder:
+                type: 'MultiEmbedder'
+                params:
+                    embedders:
+                        -   type: 'TokenEmbedder' 
+                            params:
+                                dictionary_size: {config.vcb_size}
+                                hidden_dim: {config.hdn_dim}
+                        -   type: 'PositionEmbedder'
+                            params:
+                                num_positions: {config.blk_size}
+                                hidden_dim: {config.hdn_dim}
+            layers:
+                -   num: {config.num_layers}
+                    type: 'TransformerLayer'
+                    params:
+                        hidden_dim: {config.hdn_dim}
+                        attn:
+                            type: 'Attention'
+                            params:
+                                hidden_dim: {config.hdn_dim}
+                                num_heads: {config.num_heads}
+                                dropout: {config.dropout}
+                        mlp:
+                            type: 'TokenChoiceMoE'
+                            params:
+                                hidden_dim: {config.hdn_dim}
+                                k: {config.k}
+                                experts:
+                                    -   num: {config.num_experts}
+                                        type: 'MLP'
+                                        params:
+                                            hidden_dim: {config.hdn_dim}
+                                            intermediate_dim: {config.mlp_hdn_dim}
+                                            dropout: {config.dropout}
+            head:
+                type: 'ClassificationHead'
+                params:
+                    hidden_dim: {config.hdn_dim}
+                    vocab_size: {config.vcb_size}
+        """

--- a/src/pytfex/transformer/make_model.py
+++ b/src/pytfex/transformer/make_model.py
@@ -5,7 +5,8 @@ import copy
 from pytfex.transformer.layer import TransformerLayer
 from pytfex.transformer.attention import Attention
 from pytfex.transformer.mlp import MLP
-from pytfex.transformer.moe import MoE
+from pytfex.transformer.moe_ec import ExpertChoiceMoE
+from pytfex.transformer.moe_tc import TokenChoiceMoE
 from pytfex.transformer.gpt import GPT
 from pytfex.transformer.heads import ClassificationHead, InversePatch
 from pytfex.transformer.embedders import TokenEmbedder, PositionEmbedder, \
@@ -17,7 +18,8 @@ class TransformerObjectRegistry:
         'TransformerLayer': TransformerLayer,
         'Attention': Attention,
         'MLP': MLP,
-        'MoE': MoE,
+        'ExpertChoiceMoE': ExpertChoiceMoE,
+        'TokenChoiceMoE': TokenChoiceMoE,
         'GPT': GPT,
         'ClassificationHead': ClassificationHead,
         'InversePatch': InversePatch,

--- a/src/pytfex/transformer/moe_ec.py
+++ b/src/pytfex/transformer/moe_ec.py
@@ -2,7 +2,7 @@ from typing import List
 import torch
 
 
-class MoE(torch.nn.Module):
+class ExpertChoiceMoE(torch.nn.Module):
     def __init__(
             self,
             hidden_dim: int,
@@ -19,7 +19,7 @@ class MoE(torch.nn.Module):
                 many experts are utilized by a token. Defaults to 2.
             experts (List, optional): List of experts. Each expert is a torch.nn.Module.
         """
-        super(MoE, self).__init__()
+        super(ExpertChoiceMoE, self).__init__()
         self.hidden_dim = hidden_dim
         self.c = c
         self.experts = torch.nn.ModuleList(experts)

--- a/src/pytfex/transformer/moe_tc.py
+++ b/src/pytfex/transformer/moe_tc.py
@@ -1,0 +1,74 @@
+from typing import List
+import torch
+
+
+class TokenChoiceMoE(torch.nn.Module):
+    def __init__(
+            self,
+            hidden_dim: int,
+            experts: List,
+            k: int = 2,
+        ):
+        """Mixture of Expert - token choice routing layer
+
+        See https://arxiv.org/pdf/1701.06538.pdf for more details.
+
+        Implementation based on 
+        https://github.com/huggingface/transformers/blob/main/src/transformers/models/mixtral/modeling_mixtral.py#L773
+
+        Args:
+            hidden_dim (int): hidden dimension
+            k (int, optional): Number of experts to route to. Defaults to 2.
+            experts (List, optional): List of experts. Each expert is a torch.nn.Module.
+        """
+        super(TokenChoiceMoE, self).__init__()
+        self.hidden_dim = hidden_dim
+        self.k = k
+        self.experts = torch.nn.ModuleList(experts)
+        self.num_experts = len(self.experts)
+        self.gate = torch.nn.Linear(
+            hidden_dim,
+            self.num_experts,
+            bias=False
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass
+
+        Args:
+            x (torch.Tensor): Input tensor of shape (batch_size, seq_len, hidden_dim)
+        
+        Returns:
+            torch.Tensor: Output tensor of shape (batch_size, seq_len, hidden_dim)
+        """
+        b, l, hdn_dim = x.shape
+        x = x.view(b * l, hdn_dim)
+        S = torch.sigmoid(self.gate(x))
+        G, I = torch.topk(S, self.k, dim=-1)
+        final_x = torch.zeros(
+            (b * l, hdn_dim),
+            dtype=x.dtype,
+            device=x.device
+        )
+
+        expert_mask = torch.nn.functional.one_hot(
+            I, num_classes=self.num_experts
+        ).permute(2, 1, 0)
+
+        for i, expert in enumerate(self.experts):
+            idx, top_x = torch.where(expert_mask[i])
+            if top_x.shape[0] == 0:
+                continue
+
+            top_x_list = top_x.tolist()
+            idx_list = idx.tolist()
+            current_state = x[None, top_x_list] \
+                .reshape(-1, hdn_dim)
+            current_hidden_states = expert(current_state) \
+                * G[top_x_list, idx_list, None]
+            final_x.index_add_(
+                0, top_x,
+                current_hidden_states.to(x.dtype)
+            )
+        final_x = final_x.reshape(b, l, hdn_dim)
+        return final_x

--- a/src/pytfex/transformer/tests/test_layers.py
+++ b/src/pytfex/transformer/tests/test_layers.py
@@ -1,6 +1,7 @@
 from pytfex.transformer.attention import Attention
 from pytfex.transformer.mlp import MLP
-from pytfex.transformer.moe import MoE
+from pytfex.transformer.moe_ec import ExpertChoiceMoE
+from pytfex.transformer.moe_tc import TokenChoiceMoE
 import torch
 
 
@@ -26,10 +27,26 @@ def test_MLP():
     assert t2.shape == (1, 10, 12)
 
 
-def test_MoE_MLP():
-    mlp = MoE(
+def test_expert_choice_MoE_MLP():
+    mlp = ExpertChoiceMoE(
         hidden_dim=12,
         c=2,
+        experts=[
+            MLP(
+                hidden_dim=12,
+                dropout=0.5
+            ) for _ in range(4)
+        ]
+    )
+    t1 = torch.randn((2, 10, 12))
+    t2 = mlp(t1)
+    assert t2.shape == (2, 10, 12)
+
+
+def test_token_choice_MoE_MLP():
+    mlp = TokenChoiceMoE(
+        hidden_dim=12,
+        k=2,
         experts=[
             MLP(
                 hidden_dim=12,

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -4,8 +4,9 @@ from pytfex.utils import set_seed
 
 from pytfex.models import (
     get_model,
-    GPTMoEConfig,
     GPTBasicConfig,
+    GPTTokenChoiceMoEConfig,
+    GPTExpertChoiceMoEConfig,
 )
 
 import torch
@@ -13,21 +14,25 @@ import pytest
 
 
 @pytest.fixture(params=[
-    # (model_type, hdn_dim, length, num_digits, batch_size, _, _, _)
     (GPTBasicConfig(
-        model_type='gpt-basic',
         vcb_size=3,
         hdn_dim=256,
         blk_size=12,
         batch_size=32,
     ), 6),
-    # (model_type, hdn_dim, length, num_digits, batch_size, k, num_experts, _)
-    (GPTMoEConfig(
-        model_type='gpt-moe',
+    (GPTExpertChoiceMoEConfig(
         vcb_size=3,
         hdn_dim=256,
         blk_size=12,
         c=2,
+        num_experts=4,
+        batch_size=32,
+    ), 6),
+    (GPTTokenChoiceMoEConfig(
+        vcb_size=3,
+        hdn_dim=256,
+        blk_size=12,
+        k=2,
         num_experts=4,
         batch_size=32,
     ), 6)


### PR DESCRIPTION
## What is this:

Implements token choice expert routing, taken from [here](https://arxiv.org/pdf/1701.06538.pdf). Implementation based on [huggingface mixtral of experts implementation](https://github.com/huggingface/transformers/blob/main/src/transformers/models/mixtral/modeling_mixtral.py#L773) but using sigmoid activation instead of softmax.

