### PR TITLE
Feature/kv cache

### DIFF
--- a/src/pytfex/models/__init__.py
+++ b/src/pytfex/models/__init__.py
@@ -20,6 +20,7 @@ class GPTExpertChoiceMoEConfig:
     mlp_hdn_dim: int = 1024
     dropout: float = 0.1
     num_heads: int = 4
+    blk_size: int = 26
 
 
 @dataclass

--- a/src/pytfex/models/basic.py
+++ b/src/pytfex/models/basic.py
@@ -7,6 +7,7 @@ def get_basic_gpt_config(config):
             hidden_dim: {config.hdn_dim}
             num_heads: {config.num_heads}
             dropout: {config.dropout}
+            blk_size: {config.blk_size}
             embedder:
                 type: 'MultiEmbedder'
                 params:

--- a/src/pytfex/models/ec_moe.py
+++ b/src/pytfex/models/ec_moe.py
@@ -6,6 +6,7 @@ def get_ec_moe_gpt_config(config):
             hidden_dim: {config.hdn_dim}
             num_heads: {config.num_heads}
             dropout: {config.dropout}
+            blk_size: {config.blk_size}
             embedder:
                 type: 'MultiEmbedder'
                 params:

--- a/src/pytfex/models/gumbel_sm_rel_attn.py
+++ b/src/pytfex/models/gumbel_sm_rel_attn.py
@@ -7,6 +7,7 @@ def get_gumbel_sm_rel_attn_gpt_config(config):
             hidden_dim: {config.hdn_dim}
             num_heads: {config.num_heads}
             dropout: {config.dropout}
+            blk_size: {config.blk_size}
             embedder:
                 type: 'MultiEmbedder'
                 params:

--- a/src/pytfex/models/rel_attn.py
+++ b/src/pytfex/models/rel_attn.py
@@ -7,6 +7,7 @@ def get_rel_attn_gpt_config(config):
             hidden_dim: {config.hdn_dim}
             num_heads: {config.num_heads}
             dropout: {config.dropout}
+            blk_size: {config.blk_size}
             embedder:
                 type: 'MultiEmbedder'
                 params:

--- a/src/pytfex/models/tc_moe.py
+++ b/src/pytfex/models/tc_moe.py
@@ -6,6 +6,7 @@ def get_tc_moe_gpt_config(config):
             hidden_dim: {config.hdn_dim}
             num_heads: {config.num_heads}
             dropout: {config.dropout}
+            blk_size: {config.blk_size}
             embedder:
                 type: 'MultiEmbedder'
                 params:

--- a/src/pytfex/transformer/attention.py
+++ b/src/pytfex/transformer/attention.py
@@ -76,10 +76,10 @@ class Attention(torch.nn.Module):
             a = a.masked_fill(mask, float('-inf'))
         a = torch.softmax(a, dim=-1)
         a = self.attn_dropout(a)
-        output =  (a @ v).transpose(1, 2).reshape(b, l, d)
+        output = (a @ v).transpose(1, 2).reshape(b, l, d)
         output = self.linear(output)
         output = self.resid_dropout(output)
-        return output, {'q': q, 'k': k, 'v': v}
+        return output, {'q': q, 'k': k, 'v': v, 'a': a}
 
 
 def generate_relative_positions(L):

--- a/src/pytfex/transformer/attention.py
+++ b/src/pytfex/transformer/attention.py
@@ -70,6 +70,7 @@ class Attention(torch.nn.Module):
         if use_kv_cache:
             k = torch.cat((past_k, k), dim=2)
             v = torch.cat((past_v, v), dim=2)
+            del past_k, past_v # free memory
         hd = torch.tensor(self.head_dim, dtype=torch.float32)
         a = q @ k.transpose(-2, -1) / torch.sqrt(hd)
         if mask is not None:
@@ -149,6 +150,7 @@ class RelativeAttention(torch.nn.Module):
             k = torch.cat((past_k, k), dim=2)
             v = torch.cat((past_v, v), dim=2)
             q = torch.cat((past_q, q), dim=2)
+            del past_k, past_v, past_q # free memory
 
         b, _, kv_l, _ = v.shape
         rel_pos = generate_relative_positions(kv_l)
@@ -244,6 +246,7 @@ class GumbelSoftmaxRelativeAttention(torch.nn.Module):
             k = torch.cat((past_k, k), dim=2)
             v = torch.cat((past_v, v), dim=2)
             q = torch.cat((past_q, q), dim=2)
+            del past_k, past_v, past_q # free memory
 
         b, _, kv_l, _ = v.shape
         rel_pos = generate_relative_positions(kv_l)

--- a/src/pytfex/transformer/attention.py
+++ b/src/pytfex/transformer/attention.py
@@ -169,7 +169,7 @@ class RelativeAttention(torch.nn.Module):
         output =  (a @ v).transpose(1, 2).reshape(b, l, d)
         output = self.linear(output)
         output = self.resid_dropout(output)
-        return output, {'q': q, 'k': k, 'v': v}
+        return output, {'q': q, 'k': k, 'v': v, 'a': a}
     
 
 class GumbelSoftmaxRelativeAttention(torch.nn.Module):
@@ -252,7 +252,7 @@ class GumbelSoftmaxRelativeAttention(torch.nn.Module):
         # compute attention
         hd = torch.tensor(self.head_dim, dtype=torch.float32)
         a = q @ k.transpose(-2, -1) / torch.sqrt(hd)
-        QEr = torch.einsum('bnlh,rnlkh->bnlk', q, Er)  # b, nh, l, l
+        QEr = torch.einsum('bnlh,rnlkh->bnlk', q, Er)
         a = a + QEr
 
         if use_kv_cache:
@@ -266,4 +266,4 @@ class GumbelSoftmaxRelativeAttention(torch.nn.Module):
         output =  (a @ v).transpose(1, 2).reshape(b, l, d)
         output = self.linear(output)
         output = self.resid_dropout(output)
-        return output, {'q': q, 'k': k, 'v': v}
+        return output, {'q': q, 'k': k, 'v': v, 'a': a}

--- a/src/pytfex/transformer/embedders.py
+++ b/src/pytfex/transformer/embedders.py
@@ -51,7 +51,7 @@ class PositionEmbedder(torch.nn.Module):
                 .to(x.device)
             )
         else:
-            leading_position = min(x.shape[1] + kv_cache[-1]['k'].shape[2], self.pos_emb.num_embeddings) - x.shape[1] 
+            leading_position = min(x.shape[1] + kv_cache.size(), self.pos_emb.num_embeddings) - x.shape[1] 
             positions = (torch
                 .arange(leading_position, leading_position + x.shape[1])
                 .expand(x.shape[0], -1)

--- a/src/pytfex/transformer/gpt.py
+++ b/src/pytfex/transformer/gpt.py
@@ -16,6 +16,7 @@ class GPT(torch.nn.Module, BaseTransformer):
         super(GPT, self).__init__()
         self.hidden_dim = hidden_dim
         self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
         self.dropout = dropout
 
         self.drop = nn.Dropout(dropout)
@@ -23,15 +24,23 @@ class GPT(torch.nn.Module, BaseTransformer):
         self.layers = torch.nn.ModuleList(layers)
         self.head = head
 
+    def _init_kv_cache(self):
+        return [
+            {
+                'k': torch.zeros(1, self.num_heads, 0, self.head_dim),
+                'v': torch.zeros(1, self.num_heads, 0, self.head_dim)
+            } for _ in range(len(self.layers))
+        ]
+
     def forward(self, x, mask=None, use_kv_cache=False, kv_cache=None):
         if use_kv_cache and kv_cache is not None:
             assert len(kv_cache) == len(self.layers), \
                 'kv_cache must be a list of dicts with the same length as layers'
         if kv_cache is None:
-            kv_cache = [{} for _ in range(len(self.layers))]
+            kv_cache = self._init_kv_cache()
 
         if self.embedder:
-            x = self.embedder(x)
+            x = self.embedder(x, kv_cache=kv_cache)
         x = self.drop(x)
         new_kv_cache = []
         for layer, kv_cache in zip(self.layers, kv_cache):

--- a/src/pytfex/transformer/gpt.py
+++ b/src/pytfex/transformer/gpt.py
@@ -28,7 +28,8 @@ class GPT(torch.nn.Module, BaseTransformer):
         return [
             {
                 'k': torch.zeros(1, self.num_heads, 0, self.head_dim),
-                'v': torch.zeros(1, self.num_heads, 0, self.head_dim)
+                'v': torch.zeros(1, self.num_heads, 0, self.head_dim),
+                'q': torch.zeros(1, self.num_heads, 0, self.head_dim),
             } for _ in range(len(self.layers))
         ]
 

--- a/src/pytfex/transformer/gpt.py
+++ b/src/pytfex/transformer/gpt.py
@@ -66,15 +66,12 @@ class GPT(torch.nn.Module, BaseTransformer):
             x = self.embedder(x, kv_cache=kv_cache)
         x = self.drop(x)
         for layer_idx, layer in enumerate(self.layers):
-            if use_kv_cache:
-                kv_cache_layer = kv_cache.layers[layer_idx]
-            else:
-                kv_cache_layer = None
-            x, _kv_cache = layer(
+            layer_cache = kv_cache.layers[layer_idx] if use_kv_cache else None
+            x, _ = layer(
                 x,
                 mask=mask,
                 use_kv_cache=use_kv_cache,
-                kv_cache=kv_cache_layer
+                kv_cache=layer_cache
             )
         if self.head is not None:
             x = self.head(x)

--- a/src/pytfex/transformer/layer.py
+++ b/src/pytfex/transformer/layer.py
@@ -19,7 +19,13 @@ class TransformerLayer(torch.nn.Module):
             self.hidden_dim
         )
 
-    def forward(self, x, mask=None):
-        x = x + self.attn(self.ln_1(x), mask=mask)
+    def forward(self, x, mask=None, use_kv_cache=False, kv_cache=None):
+        attn_out, kv_cache = self.attn(
+            self.ln_1(x),
+            mask=mask,
+            use_kv_cache=use_kv_cache,
+            kv_cache=kv_cache
+        )
+        x = x + attn_out
         x = x + self.mlp(self.ln_2(x))
-        return x
+        return x, kv_cache

--- a/src/pytfex/transformer/tests/test_layers.py
+++ b/src/pytfex/transformer/tests/test_layers.py
@@ -25,9 +25,9 @@ def test_attention_kv_cache():
         dropout=0.0
     )
 
-    t1 = torch.ones((2, 10, 12))
+    t1 = torch.randn((2, 10, 12))
     _t2, kv_cache = attn(t1)
-    t1 = torch.ones((2, 1, 12))
+    t1 = t1[:, [-1], :]
     kv = {'k': kv_cache['k'][:, :, :-1], 'v': kv_cache['v'][:, :, :-1]}
     t2, kv_cache = attn(t1, use_kv_cache=True, kv_cache=kv)
     assert t2.shape == (2, 1, 12)
@@ -174,8 +174,6 @@ def test_transformer_layer():
     t1 = torch.randn((1, 3, 12))
     t21, _ = layer(t1)
     t22, _ = layer(t1, use_kv_cache=True, kv_cache={})
-
-    print(t21, t22)
     for a, b in zip(
             t21[:, [-1]].flatten().tolist(),
             t22[:, [-1]].flatten().tolist()

--- a/src/pytfex/transformer/tests/test_layers.py
+++ b/src/pytfex/transformer/tests/test_layers.py
@@ -2,6 +2,7 @@ from pytfex.transformer.attention import Attention, RelativeAttention, GumbelSof
 from pytfex.transformer.mlp import MLP
 from pytfex.transformer.moe_ec import ExpertChoiceMoE
 from pytfex.transformer.moe_tc import TokenChoiceMoE
+from pytfex.transformer.layer import TransformerLayer
 import torch
 
 
@@ -12,9 +13,31 @@ def test_attention():
         dropout=0.5
     )
 
-    t1 = torch.zeros((1, 10, 12))
-    t2 = attn(t1)
+    t1 = torch.ones((1, 10, 12))
+    t2, _ = attn(t1)
     assert t2.shape == (1, 10, 12)
+
+
+def test_attention_kv_cache():
+    attn = Attention(
+        hidden_dim=12,
+        num_heads=4,
+        dropout=0.0
+    )
+
+    t1 = torch.ones((2, 10, 12))
+    _t2, kv_cache = attn(t1)
+    t1 = torch.ones((2, 1, 12))
+    kv = {'k': kv_cache['k'][:, :, :-1], 'v': kv_cache['v'][:, :, :-1]}
+    t2, kv_cache = attn(t1, use_kv_cache=True, kv_cache=kv)
+    assert t2.shape == (2, 1, 12)
+    for a, b in zip(
+            t2[:, [-1]].flatten().tolist(),
+            _t2[:, [-1]].flatten().tolist()
+        ):
+        assert abs(a - b) < 1e-6, f"{a} != {b}"
+    assert kv_cache['k'].shape == (2, 4, 10, 3)
+    assert kv_cache['v'].shape == (2, 4, 10, 3)
 
 
 def test_rel_attention():
@@ -25,9 +48,32 @@ def test_rel_attention():
         dropout=0.5
     )
 
-    t1 = torch.zeros((1, 10, 12))
-    t2 = attn(t1)
+    t1 = torch.ones((1, 10, 12))
+    t2, _ = attn(t1)
     assert t2.shape == (1, 10, 12)
+
+
+def test_rel_attention_kv_cache():
+    attn = RelativeAttention(
+        hidden_dim=12,
+        num_heads=4,
+        num_positions=10,
+        dropout=0.0
+    )
+
+    t1 = torch.ones((2, 10, 12))
+    _t2, kv_cache = attn(t1)
+    t1 = torch.ones((2, 1, 12))
+    kv = {'k': kv_cache['k'][:, :, :-1], 'v': kv_cache['v'][:, :, :-1]}
+    t2, kv_cache = attn(t1, use_kv_cache=True, kv_cache=kv)
+    assert t2.shape == (2, 1, 12)
+    for a, b in zip(
+            t2[:, [-1]].flatten().tolist(),
+            _t2[:, [-1]].flatten().tolist()
+        ):
+        assert abs(a - b) < 1e-6, f"{a} != {b}"
+    assert kv_cache['k'].shape == (2, 4, 10, 3)
+    assert kv_cache['v'].shape == (2, 4, 10, 3)
 
 
 def test_gumbel_softmax_rel_attention():
@@ -38,14 +84,36 @@ def test_gumbel_softmax_rel_attention():
         dropout=0.5
     )
 
-    t1 = torch.zeros((1, 10, 12))
-    t2 = attn(t1)
+    t1 = torch.ones((1, 10, 12))
+    t2, _ = attn(t1)
     assert t2.shape == (1, 10, 12)
 
     attn.set_tau(0.5)
     attn.set_hard(True)
-    t3 = attn(t1)
+    t3, _ = attn(t1)
     assert t3.shape == (1, 10, 12)
+
+
+def test_gumbel_softmax_rel_attention_kv_cache():
+    attn = GumbelSoftmaxRelativeAttention(
+        hidden_dim=12,
+        num_heads=4,
+        num_positions=10,
+        dropout=0.0
+    )
+    t1 = torch.ones((2, 10, 12))
+    _t2, kv_cache = attn(t1)
+    t1 = torch.ones((2, 1, 12))
+    kv = {'k': kv_cache['k'][:, :, :-1], 'v': kv_cache['v'][:, :, :-1]}
+    t2, kv_cache = attn(t1, use_kv_cache=True, kv_cache=kv)
+    assert t2.shape == (2, 1, 12)
+    for a, b in zip(
+            t2[:, [-1]].flatten().tolist(),
+            _t2[:, [-1]].flatten().tolist()
+        ):
+        assert abs(a - b) < 1e-6, f"{a} != {b}"
+    assert kv_cache['k'].shape == (2, 4, 10, 3)
+    assert kv_cache['v'].shape == (2, 4, 10, 3)
 
 
 def test_MLP():
@@ -53,7 +121,7 @@ def test_MLP():
         hidden_dim=12,
         dropout=0.5
     )
-    t1 = torch.zeros((1, 10, 12))
+    t1 = torch.ones((1, 10, 12))
     t2 = mlp(t1)
     assert t2.shape == (1, 10, 12)
 
@@ -88,3 +156,30 @@ def test_token_choice_MoE_MLP():
     t1 = torch.randn((2, 10, 12))
     t2 = mlp(t1)
     assert t2.shape == (2, 10, 12)
+
+
+def test_transformer_layer():
+    layer = TransformerLayer(
+        hidden_dim=12,
+        attn=Attention(
+            hidden_dim=12,
+            num_heads=4,
+            dropout=0.0
+        ),
+        mlp=MLP(
+            hidden_dim=12,
+            dropout=0.0
+        )
+    )
+    t1 = torch.randn((1, 3, 12))
+    t21, _ = layer(t1)
+    t22, _ = layer(t1, use_kv_cache=True, kv_cache={})
+
+    print(t21, t22)
+    for a, b in zip(
+            t21[:, [-1]].flatten().tolist(),
+            t22[:, [-1]].flatten().tolist()
+        ):
+        assert abs(a - b) < 1e-6, f"{a} != {b}"
+    assert t21.shape == (1, 3, 12)
+    assert t22.shape == (1, 3, 12)

--- a/src/pytfex/transformer/tests/test_layers.py
+++ b/src/pytfex/transformer/tests/test_layers.py
@@ -64,7 +64,11 @@ def test_rel_attention_kv_cache():
     t1 = torch.ones((2, 10, 12))
     _t2, kv_cache = attn(t1)
     t1 = torch.ones((2, 1, 12))
-    kv = {'k': kv_cache['k'][:, :, :-1], 'v': kv_cache['v'][:, :, :-1]}
+    kv = {
+        'k': kv_cache['k'][:, :, :-1],
+        'v': kv_cache['v'][:, :, :-1],
+        'q': kv_cache['q'][:, :, :-1]
+    }
     t2, kv_cache = attn(t1, use_kv_cache=True, kv_cache=kv)
     assert t2.shape == (2, 1, 12)
     for a, b in zip(
@@ -104,7 +108,11 @@ def test_gumbel_softmax_rel_attention_kv_cache():
     t1 = torch.ones((2, 10, 12))
     _t2, kv_cache = attn(t1)
     t1 = torch.ones((2, 1, 12))
-    kv = {'k': kv_cache['k'][:, :, :-1], 'v': kv_cache['v'][:, :, :-1]}
+    kv = {
+        'k': kv_cache['k'][:, :, :-1],
+        'v': kv_cache['v'][:, :, :-1],
+        'q': kv_cache['q'][:, :, :-1]
+    }
     t2, kv_cache = attn(t1, use_kv_cache=True, kv_cache=kv)
     assert t2.shape == (2, 1, 12)
     for a, b in zip(

--- a/src/tests/test_decode.py
+++ b/src/tests/test_decode.py
@@ -57,9 +57,9 @@ def test_kv_cache():
     preds_1, kv_cache_2 = model(input_ids, mask=mask, use_kv_cache=True, kv_cache=None)
     input_ids = torch.tensor([[0]])
     preds_2, kv_cache_1 = model(input_ids, use_kv_cache=True, kv_cache=kv_cache_1)
-    for cache_1, cache_2 in zip(kv_cache_1, kv_cache_2):
-        assert torch.allclose(cache_1['v'], cache_2['v'])
-        assert torch.allclose(cache_1['k'], cache_2['k'])
+    for cache_1, cache_2 in zip(kv_cache_1.layers, kv_cache_2.layers):
+        assert torch.allclose(cache_1.v, cache_2.v)
+        assert torch.allclose(cache_1.k, cache_2.k)
     assert torch.allclose(preds_1[:, -1, :], preds_2[:, -1, :])
 
 def test_kv_cache_decode(training_setup):

--- a/src/tests/test_decode.py
+++ b/src/tests/test_decode.py
@@ -1,12 +1,20 @@
 import torch
+from pytfex.models import (
+    get_model,
+    GPTBasicConfig,
+)
 from pytfex.transformer.mask import get_causal_mask
 
 
 def decode(model, config, input_ids, temp=1, limit=16, sample=True):
+    all_preds = []
     for _ in range(limit):
         input_ids = input_ids[:, -config.blk_size:]
-        preds = model(input_ids)
+        b, l = input_ids.shape
+        mask = get_causal_mask(l)
+        preds = model(input_ids, mask=mask)
         y = (preds[:, -1, :] / temp).softmax(dim=-1)
+        all_preds.append(y)
         if sample:
             next_token = torch.multinomial(y, 1)
         else:
@@ -14,7 +22,7 @@ def decode(model, config, input_ids, temp=1, limit=16, sample=True):
 
         if not sample: next_token = next_token[None]
         input_ids = torch.cat((input_ids, next_token), dim=-1)
-    return input_ids
+    return input_ids, all_preds
 
 
 def test_decode(training_setup):
@@ -25,28 +33,33 @@ def test_decode(training_setup):
             layer.attn.set_hard(True)
 
     input_ids = torch.tensor([[0, 1]])
-    result = decode(model, config, input_ids, limit=20)
-    print(result)
+    result, _ = decode(model, config, input_ids, limit=20)
 
 
-def test_kv_cache(training_setup):
-    _, model, _, config = training_setup
+def test_kv_cache():
+    config = GPTBasicConfig(
+        vcb_size=3,
+        hdn_dim=3,
+        num_heads=1,
+        blk_size=3,
+        batch_size=1,
+        dropout=0.0,
+    )
+    model = get_model(config)
     model.eval()
-    if config.model_type == 'gpt-gumbel-sm-rel-attn':
-        for layer in model.layers:
-            layer.attn.set_tau(0.0)
-            layer.attn.set_hard(True)
 
-
-    input_ids = torch.tensor([[0, 1]])
-    
-    preds_1 = model(input_ids)
-    preds_2, kv_cache = model(input_ids, use_kv_cache=True, kv_cache=None)
-    assert torch.allclose(preds_1, preds_2)
-    for cache in kv_cache:
-        assert cache['k'].shape == (1, 4, 2, 64)
-        assert cache['v'].shape == (1, 4, 2, 64)
-
+    input_ids = torch.tensor([[1]])
+    mask = get_causal_mask(1)
+    _, kv_cache_1 = model(input_ids, mask=mask, use_kv_cache=True, kv_cache=None)
+    input_ids = torch.tensor([[1, 0]])
+    mask = get_causal_mask(2)
+    preds_1, kv_cache_2 = model(input_ids, mask=mask, use_kv_cache=True, kv_cache=None)
+    input_ids = torch.tensor([[0]])
+    preds_2, kv_cache_1 = model(input_ids, use_kv_cache=True, kv_cache=kv_cache_1)
+    for cache_1, cache_2 in zip(kv_cache_1, kv_cache_2):
+        assert torch.allclose(cache_1['v'], cache_2['v'])
+        assert torch.allclose(cache_1['k'], cache_2['k'])
+    assert torch.allclose(preds_1[:, -1, :], preds_2[:, -1, :])
 
 def test_kv_cache_decode(training_setup):
     _, model, _, config = training_setup
@@ -56,16 +69,20 @@ def test_kv_cache_decode(training_setup):
             layer.attn.set_tau(0.0)
             layer.attn.set_hard(True)
 
-    input_ids = torch.tensor([[0, 1]])
-    result = decode(model, config, input_ids, limit=8, sample=False)
+    input_ids = torch.tensor([[0]])
+    result, all_preds = decode(model, config, input_ids, limit=8, sample=False)
 
-    kv_cache=[{}, {}]
+    kv_cache=None
     x = input_ids
+    all_preds_2 = []
     for _ in range(8):
         preds, kv_cache = model(x, use_kv_cache=True, kv_cache=kv_cache)
         y = (preds[:, [-1], :] / 1).softmax(dim=-1)
+        all_preds_2.append(y)
         x = torch.argmax(y, dim=-1)
         input_ids = torch.cat((input_ids, x), dim=-1)
-    print(result)
-    print(input_ids)
-    assert torch.allclose(result, input_ids)
+    assert torch.allclose(result, input_ids), f"{config.model_type} fails"
+
+    for a, b in zip(all_preds, all_preds_2):
+        # print(a, b)
+        assert torch.allclose(a, b), f"{config.model_type} fails"

--- a/src/tests/test_decode.py
+++ b/src/tests/test_decode.py
@@ -4,6 +4,7 @@ from pytfex.models import (
     GPTBasicConfig,
 )
 from pytfex.transformer.mask import get_causal_mask
+import pytest
 
 
 def decode(model, config, input_ids, temp=1, limit=16, sample=True):
@@ -64,6 +65,8 @@ def test_kv_cache():
 def test_kv_cache_decode(training_setup):
     _, model, _, config = training_setup
     model.eval()
+    if config.model_type == 'gpt-ec-moe':
+        pytest.skip("kv cache not implemented for gpt-ec-moe")
     if config.model_type == 'gpt-gumbel-sm-rel-attn':
         for layer in model.layers:
             layer.attn.set_tau(0.0)

--- a/src/tests/test_decode.py
+++ b/src/tests/test_decode.py
@@ -60,10 +60,12 @@ def test_kv_cache_decode(training_setup):
     result = decode(model, config, input_ids, limit=8, sample=False)
 
     kv_cache=[{}, {}]
+    x = input_ids
     for _ in range(8):
-        preds, kv_cache = model(input_ids, use_kv_cache=True, kv_cache=kv_cache)
+        preds, kv_cache = model(x, use_kv_cache=True, kv_cache=kv_cache)
         y = (preds[:, [-1], :] / 1).softmax(dim=-1)
-        gen_id = torch.argmax(y, dim=-1)
-        input_ids = torch.cat((input_ids, gen_id), dim=-1)
-
+        x = torch.argmax(y, dim=-1)
+        input_ids = torch.cat((input_ids, x), dim=-1)
+    print(result)
+    print(input_ids)
     assert torch.allclose(result, input_ids)

--- a/src/tests/test_decode.py
+++ b/src/tests/test_decode.py
@@ -3,15 +3,9 @@ from pytfex.transformer.mask import get_causal_mask
 
 
 def decode(model, config, input_ids, temp=1, limit=16, sample=True):
-    if config.model_type == 'gpt-gumbel-sm-rel-attn':
-        for layer in model.layers:
-            layer.attn.set_tau(0.5)
-            layer.attn.set_hard(True)
-
     for _ in range(limit):
         input_ids = input_ids[:, -config.blk_size:]
-        mask = get_causal_mask(input_ids.shape[1])
-        preds = model(input_ids, mask=mask)
+        preds = model(input_ids)
         y = (preds[:, -1, :] / temp).softmax(dim=-1)
         if sample:
             next_token = torch.multinomial(y, 1)
@@ -25,6 +19,51 @@ def decode(model, config, input_ids, temp=1, limit=16, sample=True):
 
 def test_decode(training_setup):
     _, model, _, config = training_setup
+    if config.model_type == 'gpt-gumbel-sm-rel-attn':
+        for layer in model.layers:
+            layer.attn.set_tau(0.5)
+            layer.attn.set_hard(True)
+
     input_ids = torch.tensor([[0, 1]])
     result = decode(model, config, input_ids, limit=20)
     print(result)
+
+
+def test_kv_cache(training_setup):
+    _, model, _, config = training_setup
+    model.eval()
+    if config.model_type == 'gpt-gumbel-sm-rel-attn':
+        for layer in model.layers:
+            layer.attn.set_tau(0.0)
+            layer.attn.set_hard(True)
+
+
+    input_ids = torch.tensor([[0, 1]])
+    
+    preds_1 = model(input_ids)
+    preds_2, kv_cache = model(input_ids, use_kv_cache=True, kv_cache=None)
+    assert torch.allclose(preds_1, preds_2)
+    for cache in kv_cache:
+        assert cache['k'].shape == (1, 4, 2, 64)
+        assert cache['v'].shape == (1, 4, 2, 64)
+
+
+def test_kv_cache_decode(training_setup):
+    _, model, _, config = training_setup
+    model.eval()
+    if config.model_type == 'gpt-gumbel-sm-rel-attn':
+        for layer in model.layers:
+            layer.attn.set_tau(0.0)
+            layer.attn.set_hard(True)
+
+    input_ids = torch.tensor([[0, 1]])
+    result = decode(model, config, input_ids, limit=8, sample=False)
+
+    kv_cache=[{}, {}]
+    for _ in range(8):
+        preds, kv_cache = model(input_ids, use_kv_cache=True, kv_cache=kv_cache)
+        y = (preds[:, [-1], :] / 1).softmax(dim=-1)
+        gen_id = torch.argmax(y, dim=-1)
+        input_ids = torch.cat((input_ids, gen_id), dim=-1)
+
+    assert torch.allclose(result, input_ids)


### PR DESCRIPTION
## What is this

This PR adds `kv_cache` functionality for more efficient decoding.

can be used like so:

```py
def decode_kv(model, text, temp=1, limit=16, sample=True):
    with torch.no_grad():
        model.eval()
        input_ids = torch.tensor([meta['stoi'][char] for char in text])[None]

        if torch.cuda.is_available():
            input_ids = input_ids.cuda()

        result = text
        kv_cache = None
        x = input_ids
        for _ in tqdm(range(limit)):
            b, l = x.shape
            mask = get_causal_mask(l).to(device)
            preds, kv_cache = model(x, use_kv_cache=True, mask=mask, kv_cache=kv_cache)
            y = (preds[:, -1, :] / temp).softmax(dim=-1)
            if sample:
                next_token = torch.multinomial(y, 1)
            else:
                next_token = torch.argmax(y, dim=-1)
            result += meta['itos'][next_token.item()]
            if not sample: next_token = next_token[None]
            x = next_token

        return result
````


1. See [this](https://colab.research.google.com/drive/1JhXwP-k_Nw5XS37hZ7kEESEeCQ5BAnYj#scrollTo=ufpkMaGn_ZZB) notebook for basic GPT decoding.
2. See [this](https://colab.research.google.com/drive/1_CAIp7Kz1wsPafAAr6GCCC9M1g6P5epr#scrollTo=ufpkMaGn_ZZB) notebook for relative embeddings.
 

## Notes
- This PR does not implement `kv_cache` for MOE-EC
- The KV cache used for relative posistional embeddings is really a KVQ cache and only illuminates the `self.vqk(x)` call in the attention layer. Its still a ~2x speedup but can be made better. I don't think we need to store the q for instance. 