### PR TITLE
Fix non diff kv-cache

### DIFF
--- a/src/pytfex/transformer/gpt.py
+++ b/src/pytfex/transformer/gpt.py
@@ -10,14 +10,7 @@ class KVCache:
         self.head_dim = head_dim
         self.num_heads = num_heads
         self.max_len = max_len
-        self.layers = [
-            LayerKVQCache(
-                batch_size=self.batch_size,
-                head_dim=self.head_dim,
-                num_heads=self.num_heads,
-                max_len=self.max_len
-            ) for _ in range(num_layers)
-        ]
+        self.layers = [LayerKVQCache() for _ in range(num_layers)]
 
     def size(self):
         return self.layers[-1].size()

--- a/src/pytfex/transformer/tests/test_layers.py
+++ b/src/pytfex/transformer/tests/test_layers.py
@@ -27,7 +27,9 @@ def test_attention_kv_cache():
 
     t1 = torch.randn((2, 10, 12))
     _t2, kv_cache = attn(t1, use_kv_cache=True)
-    kv_cache.i = 9
+    kv_cache.q = [kv_cache.q[-1][:, :, :-1, :]]
+    kv_cache.k = [kv_cache.k[-1][:, :, :-1, :]]
+    kv_cache.v = [kv_cache.v[-1][:, :, :-1, :]]
     t1 = t1[:, [-1], :]
     t2, kv_cache = attn(t1, use_kv_cache=True, kv_cache=kv_cache)
     assert t2.shape == (2, 1, 12)
@@ -36,9 +38,11 @@ def test_attention_kv_cache():
             _t2[:, [-1]].flatten().tolist()
         ):
         assert abs(a - b) < 1e-6, f"{a} != {b}"
-    assert kv_cache.k.shape == (2, 4, 10, 3)
-    assert kv_cache.v.shape == (2, 4, 10, 3)
-    assert kv_cache.i == 10
+    assert kv_cache.k[0].shape == (2, 4, 9, 3)
+    assert kv_cache.v[0].shape == (2, 4, 9, 3)
+    assert kv_cache.k[1].shape == (2, 4, 1, 3)
+    assert kv_cache.v[1].shape == (2, 4, 1, 3)
+    assert len(kv_cache.q) == 2
 
 
 def test_rel_attention():
@@ -65,7 +69,9 @@ def test_rel_attention_kv_cache():
     t1 = torch.randn((2, 10, 12))
     _t2, kv_cache = attn(t1, use_kv_cache=True)
     t1 = t1[:, [-1], :]
-    kv_cache.i = 9
+    kv_cache.q = [kv_cache.q[-1][:, :, :-1, :]]
+    kv_cache.k = [kv_cache.k[-1][:, :, :-1, :]]
+    kv_cache.v = [kv_cache.v[-1][:, :, :-1, :]]
     t2, kv_cache = attn(t1, use_kv_cache=True, kv_cache=kv_cache)
     assert t2.shape == (2, 1, 12)
     for a, b in zip(
@@ -73,9 +79,11 @@ def test_rel_attention_kv_cache():
             _t2[:, [-1]].flatten().tolist()
         ):
         assert abs(a - b) < 1e-6, f"{a} != {b}"
-    assert kv_cache.k.shape == (2, 4, 10, 3)
-    assert kv_cache.v.shape == (2, 4, 10, 3)
-    assert kv_cache.i == 10
+    assert kv_cache.k[0].shape == (2, 4, 9, 3)
+    assert kv_cache.v[0].shape == (2, 4, 9, 3)
+    assert kv_cache.k[1].shape == (2, 4, 1, 3)
+    assert kv_cache.v[1].shape == (2, 4, 1, 3)
+    assert len(kv_cache.q) == 2
 
 
 def test_gumbel_softmax_rel_attention():
@@ -108,7 +116,9 @@ def test_gumbel_softmax_rel_attention_kv_cache():
     t1 = torch.randn((2, 10, 12))
     _t2, kv_cache = attn(t1, use_kv_cache=True)
     t1 = t1[:, [-1], :]
-    kv_cache.i = 9
+    kv_cache.q = [kv_cache.q[-1][:, :, :-1, :]]
+    kv_cache.k = [kv_cache.k[-1][:, :, :-1, :]]
+    kv_cache.v = [kv_cache.v[-1][:, :, :-1, :]]
     t2, kv_cache = attn(t1, use_kv_cache=True, kv_cache=kv_cache)
     assert t2.shape == (2, 1, 12)
     for a, b in zip(
@@ -116,9 +126,11 @@ def test_gumbel_softmax_rel_attention_kv_cache():
             _t2[:, [-1]].flatten().tolist()
         ):
         assert abs(a - b) < 1e-6, f"{a} != {b}"
-    assert kv_cache.k.shape == (2, 4, 10, 3)
-    assert kv_cache.v.shape == (2, 4, 10, 3)
-    assert kv_cache.i == 10
+    assert kv_cache.k[0].shape == (2, 4, 9, 3)
+    assert kv_cache.v[0].shape == (2, 4, 9, 3)
+    assert kv_cache.k[1].shape == (2, 4, 1, 3)
+    assert kv_cache.v[1].shape == (2, 4, 1, 3)
+    assert len(kv_cache.q) == 2
 
 
 def test_MLP():

--- a/src/tests/test_decode.py
+++ b/src/tests/test_decode.py
@@ -58,8 +58,11 @@ def test_kv_cache():
     input_ids = torch.tensor([[0]])
     preds_2, kv_cache_1 = model(input_ids, use_kv_cache=True, kv_cache=kv_cache_1)
     for cache_1, cache_2 in zip(kv_cache_1.layers, kv_cache_2.layers):
-        assert torch.allclose(cache_1.v, cache_2.v)
-        assert torch.allclose(cache_1.k, cache_2.k)
+        q1, k1, v1 = cache_1.read()
+        q2, k2, v2 = cache_2.read()
+        assert torch.allclose(q1, q2)
+        assert torch.allclose(k1, k2)
+        assert torch.allclose(v1, v2)
     assert torch.allclose(preds_1[:, -1, :], preds_2[:, -1, :])
 
 def test_kv_cache_decode(training_setup):


### PR DESCRIPTION
# what is this

Preallocating tensors in the `kv_cache` leads to in-place operations which means we can't back prop. Instead cache now the list of generated kv tensors and concatenates them as needed. 

1. See [this](https://colab.research.google.com/drive/1JhXwP-k_Nw5XS37hZ7kEESEeCQ5BAnYj#scrollTo=ufpkMaGn_ZZB) notebook for basic GPT decoding.
2. See [this](https://colab.research.google.com/drive/1_CAIp7Kz1wsPafAAr6GCCC9M1g6P5epr#scrollTo=ufpkMaGn_ZZB) notebook for relative embeddings.

see also #13 